### PR TITLE
feat: add Dockerfile for server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:latest
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+ARG PORT=8080
+
+COPY . /HTTP-Shell
+
+WORKDIR /HTTP-Shell
+
+RUN apk update && \
+  apk --no-cache add python3 py3-pip && \
+  python3 -m venv $VIRTUAL_ENV --system-site-packages && \
+  pip install -r requirements.txt
+
+EXPOSE ${PORT}
+
+CMD python HTTP-Server.py ${PORT}

--- a/HTTP-Client.sh
+++ b/HTTP-Client.sh
@@ -18,7 +18,7 @@ fi
 
 # Functions
 GetEnv() {
-   usr="$(whoami | tr "[:upper:]" "[:lower:]")@$(hostname | tr "[:upper:]" "[:lower:]")"
+   usr="$(whoami | tr "[:upper:]" "[:lower:]")@$(uname -n | tr "[:upper:]" "[:lower:]")"
    pwd="$pwdnew"
    echo "$usr!$pwd"
 }

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ This shell is not fully interactive, but displays any errors on screen (both Win
 
 
 # Requirements
-- Python 3 for Server
+- Python 3 for Server (or Docker - see Usage section)
 - Install requirements.txt
 - Bash for Linux Client
 - PowerShell 2.0 or greater for Windows Client
-
 
 # Download
 It is recommended to clone the complete repository or download the zip file.
@@ -45,6 +44,12 @@ git clone https://github.com/JoelGMSec/HTTP-Shell
 
 [!] Usage: .\HTTP-Client.ps1 -c [HOST:PORT] -s [SLEEP] (optional)
 
+```
+
+If you wish to run server in a Docker container:
+```
+docker build -t http-shell https://github.com/JoelGMSec/HTTP-Shell.git#main
+docker run -it --rm -p 8080:8080 --name http-shell http-shell
 ```
 
 ### The detailed guide of use can be found at the following link:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 oslex
 pwinput
-readline
 neotermcolor


### PR DESCRIPTION
Hi, due to my personal OCD, I use Docker to run the server-side of your software, and it works well. So I decided to submit a PR in case someone else wants to run it in containers.

Additional changes made:
- A minor fix to the bash client script as `hostname` is not available on many Linux distros. 
- `readline` dependency is removed as it is a build-in library on most platforms except Android, iOS and WASI. Even if you need it, it is not a proper way to install. See [[pypi:readline]], [[pypi:gnureadline]], [[python:readline]]

[pypi:readline]: https://pypi.org/project/readline/
[pypi:gnureadline]: https://pypi.org/project/gnureadline/
[python:readline]: https://docs.python.org/3.15/library/readline.html

When testing the docker build command before merging, use `docker build -t http-shell https://github.com/simonmysun/HTTP-Shell.git#main` instead.